### PR TITLE
Add ship_release for full release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ ship_release_gh --no-changelog
 
 The token must have permission to create releases (typically `repo` scope for classic PATs, or appropriate fine-grained permissions).
 
+### `ship_release`
+
+Full release workflow assuming changelog is ready:
+
+```bash
+ship_changelog      # generate changelog, edit as needed
+ship_release        # release to GitHub + PyPI, bump version, push
+```
+
+This runs:
+1. `ship_release_gh --no_changelog` (commit, push, create GitHub release)
+2. `ship_pypi` (upload to PyPI)
+3. `ship_bump` (bump patch version)
+4. Commit and push the version bump
+
 ## Notes
 
 - `ship_pypi` does *not* bump your version for you — keep it explicit and boring.

--- a/fastship/release.py
+++ b/fastship/release.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 __all__ = ["GH_HOST", "DEFAULT_LABEL_GROUPS", "ShipConfig", "get_config", "bump_version", "Release", "ship_bump",
     "ship_bump_cli", "ship_pypi", "ship_pypi_cli", "ship_changelog", "ship_changelog_cli", "ship_release_gh",
-    "ship_release_gh_cli", "ship_new", "ship_new_cli", "ship_pr", "ship_pr_cli"]
+    "ship_release_gh_cli", "ship_release", "ship_release_cli", "ship_new", "ship_new_cli", "ship_pr", "ship_pr_cli"]
 
 import os, re, sys, shutil, subprocess, ast, importlib.resources
 from dataclasses import dataclass
@@ -410,6 +410,26 @@ def ship_release_gh(
 @call_parse
 @delegates(ship_release_gh)
 def ship_release_gh_cli(**kwargs): ship_release_gh(**kwargs)
+
+
+def ship_release(
+    token: str = None,  # GitHub token (FASTSHIP_TOKEN/GITHUB_TOKEN/token file used otherwise)
+    repo: str = None,   # Override repo ("OWNER/REPO")
+    repository: str = "pypi",  # PyPI repository in ~/.pypirc
+):
+    "Release to GitHub and PyPI, bump version, and push (assumes CHANGELOG.md is ready)."
+    ship_release_gh(token=token, repo=repo, no_changelog=True)
+    ship_pypi(repository=repository)
+    ship_bump()
+    run("git commit -am bump")
+    run("git push")
+
+@call_parse
+@delegates(ship_release)
+def ship_release_cli(**kwargs):
+    "Release to GitHub and PyPI, bump version, and push (assumes CHANGELOG.md is ready)."
+    ship_release(**kwargs)
+
 
 # ---------------------------------------------------------------------------
 # Project scaffolding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ ship_bump = "fastship.release:ship_bump_cli"
 ship_pypi = "fastship.release:ship_pypi_cli"
 ship_changelog = "fastship.release:ship_changelog_cli"
 ship_release_gh = "fastship.release:ship_release_gh_cli"
+ship_release = "fastship.release:ship_release_cli"
 ship_new = "fastship.release:ship_new_cli"
 ship_pr = "fastship.release:ship_pr_cli"
 


### PR DESCRIPTION
Adds `ship_release` command that runs the full release workflow:

1. `ship_release_gh --no_changelog`
2. `ship_pypi`
3. `ship_bump`
4. Commit and push version bump

Usage: `ship_changelog` to prepare, then `ship_release` to publish.