### PR TITLE
Correct first-release instructions in crate README template

### DIFF
--- a/fastship/release.py
+++ b/fastship/release.py
@@ -1637,7 +1637,7 @@ ship-release
 
 `ship-release` tags the Cargo version and pushes; CI publishes to crates.io via trusted publishing and creates the GitHub release, then fastship bumps `Cargo.toml`.
 
-First release only: register this repo's `ci.yml` as a trusted publisher for the crate on crates.io before tagging.
+First release only: publish manually with a token (`cargo publish`), then add this repo's `ci.yml` as a trusted publisher in the crate's crates.io settings; later tags publish tokenlessly via CI.
 """
 
 def _template_crate_workflow()->str:


### PR DESCRIPTION
crates.io has no PyPI-style pending publishers: a trusted-publisher config can only be added after the crate exists, so the first release must be published manually with a token. The scaffolded README told users to register the publisher before tagging, which is impossible for a new crate. The template now describes the real flow: manual first publish, then add the trusted publisher, then tokenless tag publishing via CI.